### PR TITLE
Simplifies userModel function switch statement

### DIFF
--- a/Server/api/users/util/userFunctions.js
+++ b/Server/api/users/util/userFunctions.js
@@ -62,7 +62,7 @@ function authenticateUser (req, res) {
 function userModel (user, opts) {
   switch (opts) {
     case 'admin':
-      let obj = {
+      return {
         id: user.id,
         email: user.email,
         username: user.username,
@@ -70,9 +70,8 @@ function userModel (user, opts) {
         team: user.team,
         project: user.project
       };
-      break;
     case 'user':
-      let obj = {
+      return {
         id: user.id,
         email: user.email,
         username: user.username,
@@ -81,26 +80,22 @@ function userModel (user, opts) {
         project: user.project,
         token: user.token.full
       };
-      break;
     case 'users':
-      let obj = {
+      return {
         id: user.id,
         username: user.username,
         admin: user.admin,
         team: user.team,
         project: user.project
       };
-      break;
     default:
-      let obj = {
+      return {
         id: user.id,
         username: user.username,
         team: user.team,
         project: user.project
       };
   }
-
-  return obj;
 }
 
 module.exports = {


### PR DESCRIPTION
Caused an error `SyntaxError: Identifier 'obj' has already been declared`.
Defaults to return the object instead of temporarily storing it.